### PR TITLE
Fix the updateURL in the usercss

### DIFF
--- a/github-dark-extensions.user.css
+++ b/github-dark-extensions.user.css
@@ -3,7 +3,7 @@
 @namespace   StylishThemes
 @version     0.0.0
 @homepageURL https://github.com/StylishThemes/GitHub-Dark-Extensions
-@updateURL   https://stylishthemes.github.io/GitHub-Dark-Extensions/github-dark-extensions.user.css
+@updateURL   https://raw.githubusercontent.com/StylishThemes/GitHub-Dark-Extensions/master/github-dark-extensions.user.css
 @license     BSD-2-Clause
 @author      StylishThemes
 @advanced color base-color "Base color scheme" #4f8cc9


### PR DESCRIPTION
Greetings @the-j0k3r 
Thanks a lot for your great work!

This PR changes the `@updateURL` to point to the `raw.githubusercontent.com` one  (the current one gives 404).